### PR TITLE
Add LOCF and gap-fill logic

### DIFF
--- a/doc/timeseries.md
+++ b/doc/timeseries.md
@@ -48,6 +48,41 @@ Sometimes you know older data isn't queried very often, but still don't want to 
 
 By calling `set_ts_compression_policy` on a time-series table with an appropriate interval (perhaps`'1 month'`), this extension will take care of compressing partitions (using a columnar storage method) older than the specified interval, once an hour. As with the retention policy functionality, a function is also provided for clearing any existing policy (existing partitions will not be decompressed, however).
 
+### Analytics Helpers
+
+This extension includes several functions intended to make writing correct time-series queries easier. Certain concepts can be difficult to express in standard SQL and helper functions can aid in readability and maintainability.
+
+#### `first` and `last`
+
+These two functions help clean up the syntax of a fairly common pattern: a query is grouped by one dimension, but a user wants to know what the first or last row in a group is when ordered by a _different_ dimension.
+
+For instance, you might have a cloud computing platform reporting metrics and wish to know the latest (in time) CPU utilization metric for each machine in the platform:
+
+```sql
+SELECT machine_id,
+       last(cpu_util, recorded_at)
+FROM events
+GROUP BY machine_id;
+```
+
+#### `date_bin_table`
+
+This function automates the tedium of aligning time-series values to a given width, or "stride", and makes sure to include NULL rows for any time periods where the source table has no data points.
+
+It must be called against a time-series table, but apart from that consideration using it is pretty straightforward:
+
+```sql
+SELECT * FROM date_bin_table(NULL::target_table, '1 hour');
+```
+
+The output of this query will differ from simply hitting the target table directly in three ways:
+
+  * Rows will be sorted by time, ascending
+  * The time column's values will be binned to the provided width
+  * Extra rows will be added for periods with no data. They will include the time stamp for that bin and NULL in all other columns
+
+
+
 ## Roadmap
 
 While `timeseries` is still in its early days, we have a concrete vision for the features we will be including in the future. Feedback on the importance of a given feature to customer use cases will help us better prioritize the following lists.

--- a/test/expected/basic_usage.out
+++ b/test/expected/basic_usage.out
@@ -140,9 +140,15 @@ SELECT COUNT(*) < 10 AS fewer_partitions FROM ts_part_info;
 CREATE TABLE events (
   user_id bigint,
   event_id bigint,
-  event_time timestamptz,
+  event_time timestamptz NOT NULL,
   value float
-);
+) PARTITION BY RANGE (event_time);
+SELECT enable_ts_table('events');
+ enable_ts_table 
+-----------------
+ 
+(1 row)
+
 COPY events FROM STDIN WITH (FORMAT 'csv');
 SELECT first(value, event_time), user_id FROM events GROUP BY user_id;
  first | user_id 
@@ -171,4 +177,26 @@ SELECT last(event_id, event_time), user_id FROM events GROUP BY user_id;
    12 |       2
     6 |       1
 (2 rows)
+
+SELECT last(user_id, value) top_performer,
+       locf(avg(value)) OVER (ORDER BY event_time),
+       event_time
+FROM date_bin_table(NULL::events, '1 minute',
+                    '[2020-11-04 15:50:00-08, 2020-11-04 16:00:00-08]')
+GROUP BY 3
+ORDER BY 3;
+ top_performer |        locf        |          event_time          
+---------------+--------------------+------------------------------
+               |                    | Wed Nov 04 15:50:00 2020 PST
+             2 |                1.4 | Wed Nov 04 15:51:00 2020 PST
+               |                1.4 | Wed Nov 04 15:52:00 2020 PST
+             2 |                1.5 | Wed Nov 04 15:53:00 2020 PST
+               |                1.5 | Wed Nov 04 15:54:00 2020 PST
+             2 |                1.6 | Wed Nov 04 15:55:00 2020 PST
+               |                1.6 | Wed Nov 04 15:56:00 2020 PST
+             2 |                1.7 | Wed Nov 04 15:57:00 2020 PST
+             2 |                1.8 | Wed Nov 04 15:58:00 2020 PST
+             2 | 1.9000000000000001 | Wed Nov 04 15:59:00 2020 PST
+               | 1.9000000000000001 | Wed Nov 04 16:00:00 2020 PST
+(11 rows)
 

--- a/test/expected/basic_usage.out
+++ b/test/expected/basic_usage.out
@@ -65,6 +65,12 @@ SELECT COUNT(*) > 10 AS has_partitions FROM ts_part_info;
  t
 (1 row)
 
+SELECT COUNT(*) > 0 AS "compressed?" FROM ts_part_info WHERE access_method = 'columnar';
+ compressed? 
+-------------
+ f
+(1 row)
+
 SELECT set_ts_retention_policy('measurements', '90 days');
  set_ts_retention_policy 
 -------------------------
@@ -119,7 +125,19 @@ SELECT premake FROM part_config WHERE parent_table='public.measurements';
        1
 (1 row)
 
-SELECT set_ts_retention_policy('measurements', '1 days');
+SELECT apply_compression_policy('measurements', '1 day');
+ apply_compression_policy 
+--------------------------
+ 
+(1 row)
+
+SELECT COUNT(*) > 0 AS "compressed?" FROM ts_part_info WHERE access_method = 'columnar';
+ compressed? 
+-------------
+ t
+(1 row)
+
+SELECT set_ts_retention_policy('measurements', '1 day');
  set_ts_retention_policy 
 -------------------------
  

--- a/test/sql/basic_usage.sql
+++ b/test/sql/basic_usage.sql
@@ -32,6 +32,7 @@ SELECT partition_duration, partition_lead_time FROM ts_config ORDER BY table_id:
 SELECT partition_interval, premake FROM part_config WHERE parent_table='public.measurements';
 
 SELECT COUNT(*) > 10 AS has_partitions FROM ts_part_info;
+SELECT COUNT(*) > 0 AS "compressed?" FROM ts_part_info WHERE access_method = 'columnar';
 
 SELECT set_ts_retention_policy('measurements', '90 days');
 SELECT retention_duration FROM ts_config WHERE table_id='measurements'::regclass;
@@ -45,7 +46,10 @@ SELECT set_ts_lead_time('measurements', '1 day');
 SELECT partition_lead_time FROM ts_config WHERE table_id='measurements'::regclass;
 SELECT premake FROM part_config WHERE parent_table='public.measurements';
 
-SELECT set_ts_retention_policy('measurements', '1 days');
+SELECT apply_compression_policy('measurements', '1 day');
+SELECT COUNT(*) > 0 AS "compressed?" FROM ts_part_info WHERE access_method = 'columnar';
+
+SELECT set_ts_retention_policy('measurements', '1 day');
 SELECT run_maintenance();
 SELECT COUNT(*) < 10 AS fewer_partitions FROM ts_part_info;
 


### PR DESCRIPTION
This adds a function to date-bin time-series data, including the production of missing rows (emitted as NULL values). By combining this with the provided LOCF window function, it is possible to produce dense bucketed time series entirely within PostgreSQL and with minimal SQL knowledge.