### PR TITLE
Honor open ranges in date_bin_table

### DIFF
--- a/sql/timeseries.sql
+++ b/sql/timeseries.sql
@@ -585,12 +585,13 @@ BEGIN
       SELECT %s
       FROM generate_series($2, $3, $1) date_series(date)
       LEFT JOIN data
-      ON data.binned_date = date_series.date;$query$,
+      ON data.binned_date = date_series.date
+      WHERE $4 @> date_series.date;$query$,
     part_col_name,
     target_table_id,
     part_col_name,
     tl_sql)
-  USING time_stride, lower(time_range), upper(time_range);
+  USING time_stride, lower(time_range), upper(time_range), time_range;
   RETURN;
 END;
 $function$;

--- a/test/expected/basic_usage.out
+++ b/test/expected/basic_usage.out
@@ -218,3 +218,23 @@ ORDER BY 3;
                | 1.9000000000000001 | Wed Nov 04 16:00:00 2020 PST
 (11 rows)
 
+SELECT last(user_id, value) top_performer,
+       locf(avg(value)) OVER (ORDER BY event_time),
+       event_time
+FROM date_bin_table(NULL::events, '1 minute',
+                    '(2020-11-04 15:50:00-08, 2020-11-04 16:00:00-08)')
+GROUP BY 3
+ORDER BY 3;
+ top_performer |        locf        |          event_time          
+---------------+--------------------+------------------------------
+             2 |                1.4 | Wed Nov 04 15:51:00 2020 PST
+               |                1.4 | Wed Nov 04 15:52:00 2020 PST
+             2 |                1.5 | Wed Nov 04 15:53:00 2020 PST
+               |                1.5 | Wed Nov 04 15:54:00 2020 PST
+             2 |                1.6 | Wed Nov 04 15:55:00 2020 PST
+               |                1.6 | Wed Nov 04 15:56:00 2020 PST
+             2 |                1.7 | Wed Nov 04 15:57:00 2020 PST
+             2 |                1.8 | Wed Nov 04 15:58:00 2020 PST
+             2 | 1.9000000000000001 | Wed Nov 04 15:59:00 2020 PST
+(9 rows)
+

--- a/test/sql/basic_usage.sql
+++ b/test/sql/basic_usage.sql
@@ -91,3 +91,11 @@ FROM date_bin_table(NULL::events, '1 minute',
                     '[2020-11-04 15:50:00-08, 2020-11-04 16:00:00-08]')
 GROUP BY 3
 ORDER BY 3;
+
+SELECT last(user_id, value) top_performer,
+       locf(avg(value)) OVER (ORDER BY event_time),
+       event_time
+FROM date_bin_table(NULL::events, '1 minute',
+                    '(2020-11-04 15:50:00-08, 2020-11-04 16:00:00-08)')
+GROUP BY 3
+ORDER BY 3;


### PR DESCRIPTION
Because I was unpacking the endpoints of the range into a naive BETWEEN check, ranges with open ends (i.e. non-inclusive) were not honored in the final output.

Adding a range inclusion check on the JOIN fixes the issue. Added a new test query to verify the correct behavior.

Fixes #19.